### PR TITLE
Authorize 0 as month value

### DIFF
--- a/duration.go
+++ b/duration.go
@@ -53,7 +53,9 @@ func ParseDuration(value string) (time.Duration, error) {
 		case "year":
 			d += year * time.Duration(value)
 		case "month":
-			return time.Duration(0), ErrNoMonth
+			if value != 0 {
+				return time.Duration(0), ErrNoMonth
+			}
 		case "week":
 			d += week * time.Duration(value)
 		case "day":

--- a/duration_test.go
+++ b/duration_test.go
@@ -15,7 +15,13 @@ func Test_parse_duration(t *testing.T) {
 		t.Fatalf("Expected an ErrBadFormat")
 	}
 
-	// test with month
+	// test with zero month
+	_, err = ParseDuration("P0M")
+	if err != nil {
+		t.Fatalf("Did not expect err: %v", err)
+	}
+
+	// test with non zero month
 	_, err = ParseDuration("P1M")
 	if err != ErrNoMonth {
 		t.Fatalf("Expected an ErrNoMonth")
@@ -34,10 +40,10 @@ func Test_parse_duration(t *testing.T) {
 		t.Errorf("Expected %v minutes, not %v", exp.Hours(), dur.Minutes())
 	}
 	if dur.Seconds() != exp.Seconds() {
-		t.Errorf("Expected 5 seconds, not %v", exp.Nanoseconds(), dur.Seconds())
+		t.Errorf("Expected %v seconds, not %v", exp.Seconds(), dur.Seconds())
 	}
 	if dur.Nanoseconds() != exp.Nanoseconds() {
-		t.Error("Expected %v nanoseconds, not %v", exp.Nanoseconds(), dur.Nanoseconds())
+		t.Errorf("Expected %v nanoseconds, not %v", exp.Nanoseconds(), dur.Nanoseconds())
 	}
 
 	// test with good week string
@@ -46,7 +52,7 @@ func Test_parse_duration(t *testing.T) {
 		t.Fatalf("Did not expect err: %v", err)
 	}
 	if dur.Hours() != 24*7 {
-		t.Errorf("Expected 168 hours, not %d", dur.Hours())
+		t.Errorf("Expected 168 hours, not %v", dur.Hours())
 	}
 }
 


### PR DESCRIPTION
Hello,

Thanks for your work! Your package is very convenient.  :-)

Here is a small contribution: the possibility to accept a zero-valued month.

As a matter of fact, I have to deal with a JSON payload containing a 4-minute long duration, which is formatted like this: `"P0Y0M0DT0H4M0S"` (it is generated by a PHP project).

I have also fixed some small errors in the tests.

Regars,
Matt