### PR TITLE
Evolution: init Go module, and add the management of nanoseconds

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -1,0 +1,24 @@
+name: Go CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.15
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -race -v -coverprofile=coverage.out ./...
+
+      - name: Coverage
+        run: go tool cover -func=coverage.out

--- a/README.md
+++ b/README.md
@@ -6,4 +6,3 @@ An [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) Go utility.
 
 - *Time* is not yet implemented
 - *Duration* is mostly implemented
-

--- a/duration.go
+++ b/duration.go
@@ -93,6 +93,7 @@ func FormatDuration(duration time.Duration) string {
 	hours := int(duration.Hours())
 	minutes := int(duration.Minutes()) - (hours * 60)
 	seconds := int(duration.Seconds()) - (hours*3600 + minutes*60)
+	nanoseconds := int(duration.Nanoseconds()) - (hours*3600+minutes*60+seconds)*1000000000
 
 	// we're not doing Y,M,W
 	s := "PT"
@@ -102,8 +103,9 @@ func FormatDuration(duration time.Duration) string {
 	if minutes > 0 {
 		s = fmt.Sprintf("%s%dM", s, minutes)
 	}
-	if seconds > 0 {
-		s = fmt.Sprintf("%s%dS", s, seconds)
+	if seconds > 0 || nanoseconds > 0 {
+		fseconds := float64(seconds) + float64(nanoseconds)/1000000000.0
+		s = fmt.Sprintf("%s%gS", s, fseconds)
 	}
 
 	return s

--- a/duration_test.go
+++ b/duration_test.go
@@ -73,6 +73,14 @@ func Test_format_duration(t *testing.T) {
 		t.Fatalf("bad ISO 8601 duration string: %s", s)
 	}
 
+	// Test duration with seconds and nanoseconds
+	d = time.Duration(42) * time.Second
+	d += time.Duration(123) * time.Nanosecond
+	s = FormatDuration(d)
+	if s != "PT42.000000123S" {
+		t.Fatalf("bad ISO 8601 duration string: %s", s)
+	}
+
 	// Test only minutes duration
 	d = time.Duration(20) * time.Minute
 	s = FormatDuration(d)

--- a/duration_test.go
+++ b/duration_test.go
@@ -28,8 +28,8 @@ func Test_parse_duration(t *testing.T) {
 	}
 
 	// test with good full string
-	exp, _ := time.ParseDuration("51h4m5s")
-	dur, err = ParseDuration("P2DT3H4M5S")
+	exp, _ := time.ParseDuration("51h4m5s123ns")
+	dur, err = ParseDuration("P2DT3H4M5,00000012300S")
 	if err != nil {
 		t.Fatalf("Did not expect err: %v", err)
 	}

--- a/duration_test.go
+++ b/duration_test.go
@@ -54,6 +54,15 @@ func Test_parse_duration(t *testing.T) {
 	if dur.Hours() != 24*7 {
 		t.Errorf("Expected 168 hours, not %v", dur.Hours())
 	}
+
+	// test with good year string
+	dur, err = ParseDuration("P1Y")
+	if err != nil {
+		t.Fatalf("Did not expect err: %v", err)
+	}
+	if dur.Hours() != 24*365 {
+		t.Errorf("Expected 8760 hours, not %v", dur.Hours())
+	}
 }
 
 func Test_format_duration(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/matt-ben/iso8601
+
+go 1.15


### PR DESCRIPTION
- Init go 1.15 module,
- Add the management of a fractional part for the seconds, up to the nanosecond,
- Add the "Go CI" github workflow.